### PR TITLE
Fix error when using --workers arg

### DIFF
--- a/python/unitytrainers/trainer_runner.py
+++ b/python/unitytrainers/trainer_runner.py
@@ -23,6 +23,8 @@ class TrainerRunner(object):
                 self.workers = cpu_count()
             except NotImplementedError:
                 self.workers = 1
+        else:
+            self.workers = workers
         self.logger.info('Initializing Process Pool - {0} workers'.format(self.workers))
         self.pool = futures.ProcessPoolExecutor(max_workers=self.workers)
         self.tuner.initialize()


### PR DESCRIPTION
When using the `--workers` argument in `tune.py`, we got an exception in `train_runner.py` caused by line
```
self.logger.info('Initializing Process Pool - {0} workers'.format(self.workers)
```
`self.workers` was not defined

Fixed this in this PR